### PR TITLE
Mirrors url update

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,9 +3,9 @@ import json
 
 # mirrors listed here
 MIRRORS = [
-    ('https', 'pypi.douban.com'),
+    ('https', 'pypi.doubanio.com'),
     ('https', 'pypi.fcio.net'),
-    ('http', 'pypi.tuna.tsinghua.edu.cn'),
+    ('https', 'pypi.tuna.tsinghua.edu.cn'),
     ('http', 'mirror.picosecond.org/pypi'),
     ('http', 'mirrors.aliyun.com/pypi'),
     ('http', 'pypi.pubyun.com'),


### PR DESCRIPTION
1. https://pypi.douban.com/ now will be auto-redirect to https://pypi.doubanio.com/
2. Tuna mirror now use https.